### PR TITLE
feat: AI 검사 히스토리 탭 통합 및 최신순 정렬 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.petdoc">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
         android:allowBackup="true"
@@ -20,6 +22,7 @@
         android:theme="@style/Theme.PETDoc"
         tools:targetApi="31">
 
+        <!-- 초기 진입 -->
         <activity
             android:name=".login.SplashActivity"
             android:exported="true">
@@ -28,56 +31,59 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- 로그인 -->
         <activity android:name=".login.LoginActivity" />
         <activity android:name=".login.NameInputActivity" />
         <activity android:name=".login.GenderInputActivity" />
         <activity android:name=".login.WeightInputActivity" />
         <activity android:name=".login.PhotoInputActivity" />
 
-        <activity android:name=".map.MapActivity" />
-
+        <!-- 메인 -->
         <activity android:name=".main.MainActivity" />
 
-        <!--유전병 예측-->
+        <!-- 지도 -->
+        <activity android:name=".map.MapActivity" />
+
+        <!-- 유전병 -->
         <activity android:name=".genetic.GeneticNoteActivity" />
         <activity android:name=".genetic.GeneticLoadingActivity" />
         <activity android:name=".genetic.GeneticInfoActivity" />
         <activity android:name=".genetic.GeneticAllInfoActivity" />
 
-        <activity android:name=".aiCheck.AICheckActivity"/>
+        <!-- AI 체크 -->
+        <activity android:name=".aiCheck.AICheckActivity" />
         <activity android:name=".aiCheck.eye.EyeCamActivity" />
         <activity android:name=".aiCheck.eye.EyeLoadingActivity" />
         <activity android:name=".aiCheck.eye.EyeResultActivity" />
-
         <activity android:name=".aiCheck.skin.SkinCamActivity" />
         <activity android:name=".aiCheck.skin.SkinLoadingActivity" />
         <activity android:name=".aiCheck.skin.SkinResultActivity" />
 
+        <!-- 산책 -->
         <activity android:name=".walklog.CalendarActivity" />
         <activity android:name=".walklog.WalkRecordActivity" />
 
-        <!--구글 로그인 설정 -->
+        <!-- Google 설정 -->
         <meta-data
             android:name="com.google.android.gms.auth.api.credentials.CREDENTIAL_PICKER_PRESENT"
             android:value="true" />
 
-        <!--카메라 provider 설정-->
+        <!-- Naver Map -->
+        <meta-data
+            android:name="com.naver.maps.map.NCP_KEY_ID"
+            android:value="c9zz9h5fcz" />
+
+        <!-- FileProvider -->
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.petdoc.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
-
-        <!-- Naver Map Client ID -->
-        <meta-data
-            android:name="com.naver.maps.map.NCP_KEY_ID"
-            android:value="c9zz9h5fcz" />
     </application>
-
-
 
 </manifest>

--- a/app/src/main/java/com/petdoc/aiCheck/AICheckActivity.java
+++ b/app/src/main/java/com/petdoc/aiCheck/AICheckActivity.java
@@ -9,7 +9,6 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.activity.EdgeToEdge;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
@@ -39,14 +38,12 @@ public class AICheckActivity extends BaseActivity {
     private DatabaseReference skinHistoryRef;
     private ValueEventListener skinHistoryListener;
 
+    private boolean isEyeTabSelected = true;
+
     private static final String[] LABELS = {
             "blepharitis", "eyelid_tumor", "entropion", "epiphora",
             "pigmentary_keratitis", "corneal_disease", "nuclear_sclerosis",
             "conjunctivitis", "nonulcerative_keratitis", "other"
-    };
-    private static final String[] LABELS_KO = {
-            "안검염", "안검종양", "안검내반증", "유루증", "색소침착성각막염",
-            "각막질환", "핵경화", "결막염", "비궤양성각막질환", "기타"
     };
 
     @Override
@@ -61,34 +58,42 @@ public class AICheckActivity extends BaseActivity {
         divider = findViewById(R.id.divider);
 
         findViewById(R.id.backButton).setOnClickListener(v -> {
-            Intent intent = new Intent(this, MainActivity.class);
-            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-            startActivity(intent);
+            startActivity(new Intent(this, MainActivity.class)
+                    .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP));
             finish();
         });
 
         tabEye.setOnClickListener(v -> {
-            selectTab(true);
-            startEyeHistoryRealtimeListener();
+            if (!isEyeTabSelected) {
+                isEyeTabSelected = true;
+                selectTab(true);
+                clearHistoryList();
+                removeSkinHistoryListener();
+                startEyeHistoryRealtimeListener();
+            }
         });
 
         tabSkin.setOnClickListener(v -> {
-            selectTab(false);
-            clearHistoryList();
-            removeEyeHistoryListener();
-            startSkinHistoryRealtimeListener();
+            if (isEyeTabSelected) {
+                isEyeTabSelected = false;
+                selectTab(false);
+                clearHistoryList();
+                removeEyeHistoryListener();
+                startSkinHistoryRealtimeListener();
+            }
         });
 
+        isEyeTabSelected = true;
         selectTab(true);
         startEyeHistoryRealtimeListener();
 
-        findViewById(R.id.eye_button).setOnClickListener(v -> {
-            startActivity(new Intent(this, EyeCamActivity.class));
-        });
+        findViewById(R.id.eye_button).setOnClickListener(v ->
+                startActivity(new Intent(this, EyeCamActivity.class))
+        );
 
-        findViewById(R.id.skin_button).setOnClickListener(v -> {
-            startActivity(new Intent(this, SkinCamActivity.class));
-        });
+        findViewById(R.id.skin_button).setOnClickListener(v ->
+                startActivity(new Intent(this, SkinCamActivity.class))
+        );
     }
 
     private void startEyeHistoryRealtimeListener() {
@@ -98,31 +103,44 @@ public class AICheckActivity extends BaseActivity {
         String petKey = CurrentPetManager.getInstance().getCurrentPetId();
         if (petKey == null) return;
 
-        removeEyeHistoryListener();
-
         eyeHistoryRef = FirebaseDatabase.getInstance()
                 .getReference("Users").child(uid).child(petKey).child("eyeAnalysis");
 
         eyeHistoryListener = new ValueEventListener() {
             @Override
             public void onDataChange(DataSnapshot snapshot) {
-                clearHistoryList();
                 LayoutInflater inflater = LayoutInflater.from(AICheckActivity.this);
+                List<DataSnapshot> recordList = new ArrayList<>();
 
+                // 스냅샷을 리스트로 변환
                 for (DataSnapshot record : snapshot.getChildren()) {
+                    recordList.add(record);
+                }
+
+                // createdAt 기준으로 내림차순 정렬 (최신순)
+                recordList.sort((a, b) -> {
+                    String aTime = a.child("createdAt").getValue(String.class);
+                    String bTime = b.child("createdAt").getValue(String.class);
+                    if (aTime == null) aTime = "";
+                    if (bTime == null) bTime = "";
+                    return bTime.compareTo(aTime); // 최신순 정렬
+                });
+
+                // 기록 아이템 생성 및 화면에 추가
+                for (DataSnapshot record : recordList) {
                     DataSnapshot predSnap = record.child("prediction");
                     if (!predSnap.exists()) continue;
 
-                    float[] leftResult = new float[LABELS.length];
-                    float[] rightResult = new float[LABELS.length];
+                    float[] result = new float[LABELS.length];
                     float sum = 0f;
                     int count = 0;
 
+                    // 예측값 계산
                     for (int i = 0; i < LABELS.length; i++) {
                         Float value = predSnap.child(LABELS[i]).getValue(Float.class);
                         if (value != null) {
-                            leftResult[i] = value / 100f;
-                            sum += leftResult[i];
+                            result[i] = value / 100f;
+                            sum += result[i];
                             count++;
                         }
                     }
@@ -131,25 +149,22 @@ public class AICheckActivity extends BaseActivity {
                     String date = record.child("createdAt").getValue(String.class);
                     if (date == null) date = getNow("yyyy.MM.dd(EE) HH:mm");
                     String side = record.child("side").getValue(String.class);
-                    String leftUri = record.child("imagePath").getValue(String.class);
+                    String uri = record.child("imagePath").getValue(String.class);
 
                     EyeHistoryItem item = new EyeHistoryItem(date, avg, side, "");
 
+                    // 카드 뷰 생성 및 데이터 설정
                     View card = inflater.inflate(R.layout.item_eye_history_card, historySection, false);
-                    TextView dateView = card.findViewById(R.id.historyDate);
-                    TextView titleView = card.findViewById(R.id.historyTitle);
-                    TextView scoreView = card.findViewById(R.id.historyScore);
+                    ((TextView) card.findViewById(R.id.historyDate)).setText(item.dateTime);
+                    ((TextView) card.findViewById(R.id.historyTitle)).setText("종합 안구 건강도");
+                    ((TextView) card.findViewById(R.id.historyScore)).setText(String.format("%.0f%%", item.score * 100));
 
-                    if (dateView != null) dateView.setText(item.dateTime);
-                    if (titleView != null) titleView.setText("종합 안구 건강도");
-                    if (scoreView != null) scoreView.setText(String.format("%.0f%%", item.score * 100));
-
+                    // 결과 상세 화면으로 이동하는 클릭 리스너 설정
                     card.setOnClickListener(view -> {
                         Intent intent = new Intent(AICheckActivity.this, EyeResultActivity.class);
                         intent.putExtra("summary_item", item);
-                        intent.putExtra("left_result", leftResult);
-                        intent.putExtra("right_result", rightResult);
-                        intent.putExtra("left_image_uri", leftUri);
+                        intent.putExtra("left_result", result);
+                        intent.putExtra("left_image_uri", uri);
                         intent.putExtra("right_image_uri", (String) null);
                         startActivity(intent);
                     });
@@ -159,11 +174,15 @@ public class AICheckActivity extends BaseActivity {
             }
 
             @Override
-            public void onCancelled(DatabaseError error) {}
+            public void onCancelled(DatabaseError error) {
+                // 데이터베이스 에러 발생 시 처리 로직 (필요 시 로깅 등 추가 가능)
+            }
         };
 
-        eyeHistoryRef.addValueEventListener(eyeHistoryListener);
+        // 최초 1회 데이터만 불러오도록 설정
+        eyeHistoryRef.addListenerForSingleValueEvent(eyeHistoryListener);
     }
+
 
     private void startSkinHistoryRealtimeListener() {
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
@@ -172,16 +191,36 @@ public class AICheckActivity extends BaseActivity {
         String petKey = CurrentPetManager.getInstance().getCurrentPetId();
         if (petKey == null) return;
 
+        removeSkinHistoryListener();
+
         skinHistoryRef = FirebaseDatabase.getInstance()
                 .getReference("Users").child(uid).child(petKey).child("skinAnalysis");
 
         skinHistoryListener = new ValueEventListener() {
             @Override
             public void onDataChange(DataSnapshot snapshot) {
+                if (isEyeTabSelected) return;
                 clearHistoryList();
+
                 LayoutInflater inflater = LayoutInflater.from(AICheckActivity.this);
 
+                List<DataSnapshot> recordList = new ArrayList<>();
+                // 스냅샷을 리스트로 변환
                 for (DataSnapshot record : snapshot.getChildren()) {
+                    recordList.add(record);
+                }
+
+                // createdAt 기준 내림차순 정렬 (최신순)
+                recordList.sort((a, b) -> {
+                    String aTime = a.child("createdAt").getValue(String.class);
+                    String bTime = b.child("createdAt").getValue(String.class);
+                    if (aTime == null) aTime = "";
+                    if (bTime == null) bTime = "";
+                    return bTime.compareTo(aTime);
+                });
+
+                // 정렬된 리스트를 기준으로 기록 화면에 추가
+                for (DataSnapshot record : recordList) {
                     Map<String, Object> rawPrediction = (Map<String, Object>) record.child("prediction").getValue();
                     if (rawPrediction == null) continue;
 
@@ -189,8 +228,8 @@ public class AICheckActivity extends BaseActivity {
                     int sum = 0;
                     int count = 0;
                     for (Map.Entry<String, Object> entry : rawPrediction.entrySet()) {
-                        Object value = entry.getValue();
                         int intVal = 0;
+                        Object value = entry.getValue();
                         if (value instanceof Long) intVal = ((Long) value).intValue();
                         else if (value instanceof Integer) intVal = (Integer) value;
                         prediction.put(entry.getKey(), intVal);
@@ -204,13 +243,9 @@ public class AICheckActivity extends BaseActivity {
                     if (date == null) date = getNow("yyyy.MM.dd(EE) HH:mm");
 
                     View card = inflater.inflate(R.layout.item_skin_history_card, historySection, false);
-                    TextView dateView = card.findViewById(R.id.historyDate);
-                    TextView titleView = card.findViewById(R.id.historyTitle);
-                    TextView scoreView = card.findViewById(R.id.historyScore);
-
-                    if (dateView != null) dateView.setText(date);
-                    if (titleView != null) titleView.setText("종합 피부 건강도");
-                    if (scoreView != null) scoreView.setText(avg + "%");
+                    ((TextView) card.findViewById(R.id.historyDate)).setText(date);
+                    ((TextView) card.findViewById(R.id.historyTitle)).setText("종합 피부 건강도");
+                    ((TextView) card.findViewById(R.id.historyScore)).setText(avg + "%");
 
                     card.setOnClickListener(view -> {
                         Intent intent = new Intent(AICheckActivity.this, SkinResultActivity.class);
@@ -224,7 +259,9 @@ public class AICheckActivity extends BaseActivity {
             }
 
             @Override
-            public void onCancelled(DatabaseError error) {}
+            public void onCancelled(DatabaseError error) {
+                // 데이터베이스 오류 발생 시 처리 필요하면 추가
+            }
         };
 
         skinHistoryRef.addValueEventListener(skinHistoryListener);
@@ -237,10 +274,18 @@ public class AICheckActivity extends BaseActivity {
         }
     }
 
+    private void removeSkinHistoryListener() {
+        if (skinHistoryRef != null && skinHistoryListener != null) {
+            skinHistoryRef.removeEventListener(skinHistoryListener);
+            skinHistoryListener = null;
+        }
+    }
+
     @Override
     protected void onDestroy() {
         super.onDestroy();
         removeEyeHistoryListener();
+        removeSkinHistoryListener();
     }
 
     private void selectTab(boolean isEye) {
@@ -253,9 +298,7 @@ public class AICheckActivity extends BaseActivity {
     }
 
     private void clearHistoryList() {
-        int base = 3;
-        while (historySection.getChildCount() > base)
-            historySection.removeViewAt(base);
+        historySection.removeAllViews();
     }
 
     private String getNow(String format) {

--- a/app/src/main/java/com/petdoc/aiCheck/eye/EyeCamActivity.java
+++ b/app/src/main/java/com/petdoc/aiCheck/eye/EyeCamActivity.java
@@ -9,13 +9,11 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.FileProvider;
 
 import com.petdoc.R;
@@ -26,14 +24,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-/**
- * 안구 이미지 입력 페이지
- * 사용자로부터 왼쪽/오른쪽 눈 이미지를 선택(앨범/카메라) 받고
- * 이후 진단을 시작하는 액티비티
- */
 public class EyeCamActivity extends BaseActivity {
 
-    // UI 요소
     private ImageView previewImage;
     private ImageView placeholderIcon;
     private ImageButton albumButton;
@@ -42,16 +34,10 @@ public class EyeCamActivity extends BaseActivity {
     private ImageView rightEyeIcon;
     private Button btnCheck;
 
-    // 좌우 눈 이미지 정보 (Bitmap 및 Uri)
-    private Bitmap leftEyeBitmap;
-    private Bitmap rightEyeBitmap;
     private Uri leftEyeUri;
     private Uri rightEyeUri;
-
-    // 현재 선택된 눈 (true: 왼쪽, false: 오른쪽)
     private boolean isLeftSelected = true;
 
-    // 갤러리에서 이미지 선택 후 결과 처리
     private final ActivityResultLauncher<Intent> galleryLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(),
             result -> {
@@ -63,14 +49,16 @@ public class EyeCamActivity extends BaseActivity {
                 }
             });
 
-    // 카메라로 사진 촬영 후 결과 처리
     private final ActivityResultLauncher<Intent> cameraLauncher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(),
             result -> {
                 if (result.getResultCode() == RESULT_OK && result.getData() != null) {
                     Bitmap photo = (Bitmap) result.getData().getExtras().get("data");
                     if (photo != null) {
-                        onCameraCaptured(photo);
+                        Uri photoUri = saveBitmapAndGetUri(photo);
+                        if (photoUri != null) {
+                            onImageSelected(photoUri);
+                        }
                     }
                 }
             });
@@ -81,7 +69,6 @@ public class EyeCamActivity extends BaseActivity {
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_eye_cam);
 
-        // UI 요소 초기화
         previewImage = findViewById(R.id.previewImage);
         placeholderIcon = findViewById(R.id.placeholderIcon);
         albumButton = findViewById(R.id.albumButton);
@@ -90,110 +77,64 @@ public class EyeCamActivity extends BaseActivity {
         rightEyeIcon = findViewById(R.id.rightEyeIcon);
         btnCheck = findViewById(R.id.btnCheck);
 
-        // 뒤로가기 버튼
         findViewById(R.id.backButton).setOnClickListener(v -> finish());
 
-        // 왼쪽 눈 선택
         leftEyeIcon.setOnClickListener(v -> {
             isLeftSelected = true;
             updateEyeToggle();
             updatePreview();
         });
 
-        // 오른쪽 눈 선택
         rightEyeIcon.setOnClickListener(v -> {
             isLeftSelected = false;
             updateEyeToggle();
             updatePreview();
         });
 
-        // 앨범 버튼 클릭 → 갤러리 실행
         albumButton.setOnClickListener(v -> {
             Intent intent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
             galleryLauncher.launch(intent);
         });
 
-        // 카메라 버튼 클릭 → 카메라 실행
         cameraButton.setOnClickListener(v -> {
             Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
             cameraLauncher.launch(intent);
         });
 
-        // 진단 시작 버튼
         btnCheck.setOnClickListener(v -> {
-            boolean hasLeft = leftEyeUri != null;
-            boolean hasRight = rightEyeUri != null;
-
-            if (!hasLeft && !hasRight) {
+            if (leftEyeUri == null && rightEyeUri == null) {
                 Toast.makeText(this, "왼쪽 또는 오른쪽 이미지를 선택해 주세요.", Toast.LENGTH_SHORT).show();
                 return;
             }
 
-            // 진단 로딩 액티비티로 이동
             Intent intent = new Intent(this, EyeLoadingActivity.class);
-            if (hasLeft) {
-                intent.putExtra("left_image_uri", leftEyeUri.toString());
-            }
-            if (hasRight) {
-                intent.putExtra("right_image_uri", rightEyeUri.toString());
-            }
+            if (leftEyeUri != null) intent.putExtra("left_image_uri", leftEyeUri.toString());
+            if (rightEyeUri != null) intent.putExtra("right_image_uri", rightEyeUri.toString());
 
-            // 현재 선택된 반려동물 ID 전달
             String petId = CurrentPetManager.getInstance().getCurrentPetId();
-            if (petId != null) {
-                intent.putExtra("pet_id", petId);
-            }
+            if (petId != null) intent.putExtra("pet_id", petId);
 
             startActivity(intent);
         });
 
-        // 버튼 초기 상태 업데이트
         updateCheckButtonState();
     }
 
-    /**
-     * 갤러리에서 이미지 선택 처리
-     */
     private void onImageSelected(Uri uri) {
         if (isLeftSelected) {
             leftEyeUri = uri;
-            leftEyeBitmap = null;
         } else {
             rightEyeUri = uri;
-            rightEyeBitmap = null;
         }
         updatePreview();
         updateCheckButtonState();
     }
 
-    /**
-     * 카메라 촬영 이미지 처리 및 저장
-     */
-    private void onCameraCaptured(Bitmap bitmap) {
-        if (isLeftSelected) {
-            leftEyeBitmap = bitmap;
-            leftEyeUri = saveBitmapAndGetUri(bitmap);
-        } else {
-            rightEyeBitmap = bitmap;
-            rightEyeUri = saveBitmapAndGetUri(bitmap);
-        }
-        updatePreview();
-        updateCheckButtonState();
-    }
-
-    /**
-     * 현재 선택된 눈의 이미지 미리보기 표시
-     */
     private void updatePreview() {
-        Bitmap currentBitmap = isLeftSelected ? leftEyeBitmap : rightEyeBitmap;
         Uri currentUri = isLeftSelected ? leftEyeUri : rightEyeUri;
 
         if (currentUri != null) {
             previewImage.setImageURI(currentUri);
-            previewImage.setVisibility(View.VISIBLE);
-            placeholderIcon.setVisibility(View.GONE);
-        } else if (currentBitmap != null) {
-            previewImage.setImageBitmap(currentBitmap);
             previewImage.setVisibility(View.VISIBLE);
             placeholderIcon.setVisibility(View.GONE);
         } else {
@@ -202,24 +143,15 @@ public class EyeCamActivity extends BaseActivity {
         }
     }
 
-    /**
-     * 좌/우 눈 선택 토글 UI 업데이트
-     */
     private void updateEyeToggle() {
         leftEyeIcon.setImageResource(isLeftSelected ? R.drawable.ic_eye_black : R.drawable.ic_eye_gray);
         rightEyeIcon.setImageResource(isLeftSelected ? R.drawable.ic_eye_gray : R.drawable.ic_eye_black);
     }
 
-    /**
-     * 진단 버튼 활성화 상태 업데이트
-     */
     private void updateCheckButtonState() {
         btnCheck.setEnabled(leftEyeUri != null || rightEyeUri != null);
     }
 
-    /**
-     * Bitmap 이미지를 임시 파일로 저장하고 Uri 반환
-     */
     private Uri saveBitmapAndGetUri(Bitmap bitmap) {
         try {
             File file = new File(getCacheDir(), "eye_" + System.currentTimeMillis() + ".jpg");

--- a/app/src/main/java/com/petdoc/aiCheck/eye/EyeResultActivity.java
+++ b/app/src/main/java/com/petdoc/aiCheck/eye/EyeResultActivity.java
@@ -22,21 +22,19 @@ import java.util.Locale;
 /**
  * EyeResultActivity
  * - 안구 진단 결과를 시각적으로 보여주는 화면
- * - 전체 건강도 요약, 질병별 확률, 이미지 미리보기 등을 표시
+ * - 전체 건강도 요약, 지병별 확률, 이미지 미리보기 등을 표시
  */
 public class EyeResultActivity extends BaseActivity {
 
-    // 영문 질병 라벨 (모델 키)
     private static final String[] LABELS = {
             "blepharitis", "eyelid_tumor", "entropion", "epiphora",
             "pigmentary_keratitis", "corneal_disease", "nuclear_sclerosis",
             "conjunctivitis", "nonulcerative_keratitis", "other"
     };
 
-    // 한글 라벨 (UI 표시용)
     private static final String[] LABELS_KO = {
-            "안검염", "안검종양", "안검내반증", "유루증", "색소침착성각막염",
-            "각막질환", "핵경화", "결막염", "비궤양성각막질환", "기타"
+            "안감엔", "안감종양", "안감내반증", "유루증", "색소치착성갑림엔",
+            "각림질학", "향가화", "결림엔", "비귀양성각림질학", "기타"
     };
 
     @Override
@@ -45,7 +43,6 @@ public class EyeResultActivity extends BaseActivity {
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_eye_result);
 
-        // 뒤로 가기 → AI 검사 메인 화면으로 이동
         findViewById(R.id.back_button).setOnClickListener(v -> {
             Intent intent = new Intent(this, com.petdoc.aiCheck.AICheckActivity.class);
             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
@@ -53,28 +50,16 @@ public class EyeResultActivity extends BaseActivity {
             finish();
         });
 
-        // 현재 날짜 표시
         TextView dateView = findViewById(R.id.result_date);
         dateView.setText(getNow("yyyy.MM.dd(E) HH:mm"));
 
-        // 예측 결과 및 요약 정보 수신
         float[] leftResult = (float[]) getIntent().getSerializableExtra("left_result");
         float[] rightResult = (float[]) getIntent().getSerializableExtra("right_result");
         EyeHistoryItem summary = (EyeHistoryItem) getIntent().getSerializableExtra("summary_item");
 
-        // 이미지 URI 파싱
-        Uri leftEyeUri = null;
-        Uri rightEyeUri = null;
-        try {
-            String leftStr = getIntent().getStringExtra("left_image_uri");
-            String rightStr = getIntent().getStringExtra("right_image_uri");
-            if (leftStr != null) leftEyeUri = Uri.parse(leftStr);
-            if (rightStr != null) rightEyeUri = Uri.parse(rightStr);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        Uri leftEyeUri = parseUri(getIntent().getStringExtra("left_image_uri"));
+        Uri rightEyeUri = parseUri(getIntent().getStringExtra("right_image_uri"));
 
-        // 종합 진단 요약 블록 처리
         View summaryBlock = findViewById(R.id.summary_block_wrapper);
         if (summaryBlock != null && summary != null) {
             TextView summaryTitle = summaryBlock.findViewById(R.id.summary_title);
@@ -88,7 +73,6 @@ public class EyeResultActivity extends BaseActivity {
             int avgPercent = Math.round(summary.score * 100);
             int color = getStatusColor(getStatus(summary.score));
 
-            // 왼쪽 눈 결과 표시
             if ("left".equals(summary.side) || "both".equals(summary.side)) {
                 leftScore.setText(avgPercent + "%");
                 leftScore.setTextColor(color);
@@ -97,7 +81,6 @@ public class EyeResultActivity extends BaseActivity {
                 leftScore.setTextColor(getStatusColor("선택안함"));
             }
 
-            // 오른쪽 눈 결과 표시
             if ("right".equals(summary.side) || "both".equals(summary.side)) {
                 rightScore.setText(avgPercent + "%");
                 rightScore.setTextColor(color);
@@ -106,16 +89,13 @@ public class EyeResultActivity extends BaseActivity {
                 rightScore.setTextColor(getStatusColor("선택안함"));
             }
 
-            // 이미지 미리보기 로드
             if (leftEyeUri != null) Glide.with(this).load(leftEyeUri).into(leftImg);
             if (rightEyeUri != null) Glide.with(this).load(rightEyeUri).into(rightImg);
         }
 
-        // 질병별 결과 카드 생성
         LinearLayout cardContainer = findViewById(R.id.result_card_container);
 
         for (int i = 0; i < LABELS.length; i++) {
-            // 카드 레이아웃 inflate
             View card = getLayoutInflater().inflate(R.layout.item_eye_result_card, cardContainer, false);
 
             TextView label = card.findViewById(R.id.eye_part_label);
@@ -126,7 +106,6 @@ public class EyeResultActivity extends BaseActivity {
 
             label.setText(LABELS_KO[i]);
 
-            // 왼쪽 눈 질병 확률
             if (leftResult != null && i < leftResult.length) {
                 int percent = Math.round(leftResult[i] * 100);
                 leftScore.setText(percent + "%");
@@ -136,17 +115,15 @@ public class EyeResultActivity extends BaseActivity {
                 leftScore.setTextColor(getStatusColor("선택안함"));
             }
 
-            // 오른쪽 눈 질병 확률
             if (rightResult != null && i < rightResult.length) {
                 int percent = Math.round(rightResult[i] * 100);
                 rightScore.setText(percent + "%");
                 rightScore.setTextColor(getStatusColor(getStatus(rightResult[i])));
             } else {
-                rightScore.setText("선택안함");
-                rightScore.setTextColor(getStatusColor("선택안함"));
+                rightScore.setText("\uc120\ud0dd\uc548\ud568");
+                rightScore.setTextColor(getStatusColor("\uc120\ud0dd\uc548\ud568"));
             }
 
-            // 이미지 표시 (같은 이미지 반복 표시)
             if (leftEyeUri != null) Glide.with(this).load(leftEyeUri).into(leftImg);
             if (rightEyeUri != null) Glide.with(this).load(rightEyeUri).into(rightImg);
 
@@ -154,31 +131,30 @@ public class EyeResultActivity extends BaseActivity {
         }
     }
 
-    /**
-     * 점수값에 따른 상태 분류
-     */
     private String getStatus(float v) {
-        if (v >= 0.6f) return "의심";     // 위험
-        else if (v >= 0.3f) return "주의"; // 경고
-        else return "안심";              // 정상
+        if (v >= 0.6f) return "의심";
+        else if (v >= 0.3f) return "주의";
+        else return "안심";
     }
 
-    /**
-     * 상태에 따른 텍스트 색상 반환
-     */
     private int getStatusColor(String status) {
         switch (status) {
-            case "의심": return 0xFFD32F2F; // 빨강
-            case "주의": return 0xFF4CAF50; // 초록
-            case "안심": return 0xFF377DFF; // 파랑
-            default: return 0xFFBDBDBD;     // 회색 (선택안함 등)
+            case "의심": return 0xFFD32F2F;
+            case "주의": return 0xFF4CAF50;
+            case "안심": return 0xFF377DFF;
+            default: return 0xFFBDBDBD;
         }
     }
 
-    /**
-     * 현재 시간 문자열 반환
-     */
     private String getNow(String format) {
         return new SimpleDateFormat(format, Locale.KOREAN).format(new Date());
+    }
+
+    private Uri parseUri(String uriStr) {
+        try {
+            return (uriStr != null) ? Uri.parse(uriStr) : null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/app/src/main/java/com/petdoc/aiCheck/skin/SkinResultActivity.java
+++ b/app/src/main/java/com/petdoc/aiCheck/skin/SkinResultActivity.java
@@ -1,16 +1,15 @@
 package com.petdoc.aiCheck.skin;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.ImageButton;
 
 import androidx.activity.EdgeToEdge;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.bumptech.glide.Glide;
 import com.petdoc.R;
@@ -50,26 +49,28 @@ public class SkinResultActivity extends BaseActivity {
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_skin_result);
 
-        // 뒤로가기 버튼 클릭 시 AICheckActivity로 이동
-        findViewById(R.id.backButton).setOnClickListener(v -> {
-            Intent intent = new Intent(this, AICheckActivity.class);
-            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-            startActivity(intent);
-            finish();
-        });
+        //  뒤로 가기 버튼
+        ImageButton backButton = findViewById(R.id.back_button);
+        if (backButton != null) {
+            backButton.setOnClickListener(v -> {
+                Intent intent = new Intent(this, AICheckActivity.class);
+                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                startActivity(intent);
+                finish();
+            });
+        }
 
         // 날짜 표시
         TextView dateText = findViewById(R.id.result_date);
         String now = new SimpleDateFormat("yyyy.MM.dd(E) HH:mm", Locale.KOREAN).format(new Date());
         dateText.setText(now);
 
-        // 결과 수신
+        // 결과 및 이미지 URI 수신
         Map<String, Integer> resultMap = (HashMap<String, Integer>) getIntent().getSerializableExtra("result_map");
         if (resultMap == null) return;
         String imageUriStr = getIntent().getStringExtra("image_uri");
-        Uri imageUri = imageUriStr != null ? Uri.parse(imageUriStr) : null;
 
-        // 종합 점수
+        // 종합 점수 계산
         int total = 0;
         for (int score : resultMap.values()) total += score;
         int average = resultMap.size() > 0 ? total / resultMap.size() : 0;
@@ -78,17 +79,17 @@ public class SkinResultActivity extends BaseActivity {
         TextView summaryScore = findViewById(R.id.summaryScore);
         if (summaryScore != null) summaryScore.setText(average + "%");
 
-        // 종합 이미지
+        //  종합 이미지 표시
         ImageView summaryImage = findViewById(R.id.summary_image);
         if (summaryImage != null) {
-            if (imageUri != null) {
-                Glide.with(this).load(imageUri).into(summaryImage);
+            if (imageUriStr != null) {
+                Glide.with(this).load(imageUriStr).into(summaryImage);
             } else {
                 summaryImage.setImageResource(R.drawable.ic_camera_placeholder);
             }
         }
 
-        // 상세 결과 카드 추가
+        // 결과 카드 목록 구성
         LinearLayout resultContainer = findViewById(R.id.skin_result_card_container);
         LayoutInflater inflater = LayoutInflater.from(this);
 
@@ -109,13 +110,14 @@ public class SkinResultActivity extends BaseActivity {
 
             View card = inflater.inflate(R.layout.item_skin_result_card, resultContainer, false);
             ((TextView) card.findViewById(R.id.condition_title)).setText(displayLabel);
+
             TextView scoreView = card.findViewById(R.id.condition_score);
             scoreView.setText(score + "%");
             scoreView.setTextColor(color);
 
             ImageView imageView = card.findViewById(R.id.condition_image);
-            if (imageUri != null) {
-                Glide.with(this).load(imageUri).into(imageView);
+            if (imageUriStr != null) {
+                Glide.with(this).load(imageUriStr).into(imageView);
             } else {
                 imageView.setImageResource(R.drawable.ic_camera_placeholder);
             }

--- a/app/src/main/res/drawable/ic_skin_placeholder.xml
+++ b/app/src/main/res/drawable/ic_skin_placeholder.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+
+    <!-- 피부 표면 (파형 선) -->
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="2"
+        android:pathData="M10,24c4,0 4,-4 8,-4s4,4 8,4s4,-4 8,-4s4,4 8,4s4,-4 8,-4s4,4 8,4" />
+
+    <!-- 중앙 모낭 (방울 형태) -->
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="2.5"
+        android:pathData="M36,24c0,0 0,12 -6,16s-6,8 -6,8" />
+
+    <!-- 피부층 하단 직선 -->
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="2"
+        android:pathData="M8,56h56" />
+
+    <!-- 모공 주변 점들 (피부 질감 표현용) -->
+    <path android:fillColor="#000000" android:pathData="M14,42a2,2 0 1,0 4,0a2,2 0 1,0 -4,0" />
+    <path android:fillColor="#000000" android:pathData="M24,50a2,2 0 1,0 4,0a2,2 0 1,0 -4,0" />
+    <path android:fillColor="#000000" android:pathData="M34,45a2,2 0 1,0 4,0a2,2 0 1,0 -4,0" />
+    <path android:fillColor="#000000" android:pathData="M44,50a2,2 0 1,0 4,0a2,2 0 1,0 -4,0" />
+    <path android:fillColor="#000000" android:pathData="M52,42a2,2 0 1,0 4,0a2,2 0 1,0 -4,0" />
+</vector>

--- a/app/src/main/res/layout/activity_skin_cam.xml
+++ b/app/src/main/res/layout/activity_skin_cam.xml
@@ -8,152 +8,178 @@
     android:background="#FFFFFF"
     tools:context=".aiCheck.skin.SkinCamActivity">
 
-    <!-- 🔙 뒤로 가기 버튼 -->
-
-    <!-- 메인 타이틀 -->
-    <ImageView
-        android:id="@+id/backButton"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="60dp"
-        android:contentDescription="뒤로 가기"
-        android:src="@drawable/ic_arrow_back"
-        app:layout_constraintEnd_toStartOf="@+id/titleText"
-        app:layout_constraintHorizontal_bias="0.252"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/titleText"
-        android:layout_width="wrap_content"
+    <!-- 상단 내비게이션 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_top_nav"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="AI 스마트 간편 검진"
-        android:textColor="#000000"
-        android:textSize="18sp"
-        android:textStyle="bold"
+        android:layout_marginTop="20dp"
+        android:layout_marginHorizontal="20dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="44dp"/>
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageButton
+            android:id="@+id/backButton"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_margin="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_arrow_back"
+            android:contentDescription="뒤로 가기"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <TextView
+            android:id="@+id/titleText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="AI 스마트 간편 검진"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <!-- 부제목 -->
     <TextView
         android:id="@+id/cameraTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:gravity="center"
         android:text="피부 AI 카메라"
-        android:textSize="22sp"
+        android:textSize="28sp"
         android:textStyle="bold"
         android:textColor="#000000"
-        app:layout_constraintTop_toBottomOf="@id/titleText"
+        app:layout_constraintTop_toBottomOf="@id/layout_top_nav"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="24dp"/>
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <!-- 📷 프리뷰 영역 -->
     <FrameLayout
         android:id="@+id/previewArea"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginHorizontal="32dp"
-        android:background="@drawable/rounded_bg"
-        android:elevation="6dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-30dp"
         app:layout_constraintTop_toBottomOf="@id/cameraTitle"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintDimensionRatio="1:1">
+        app:layout_constraintEnd_toEndOf="parent">
 
-        <!-- 빈 상태용 아이콘 -->
+        <!-- 배경 프레임 -->
         <ImageView
-            android:id="@+id/placeholderIcon"
-            android:layout_width="64dp"
-            android:layout_height="64dp"
-            android:layout_gravity="center"
-            android:src="@drawable/ic_star_gradient"
-            android:contentDescription="플레이스홀더 아이콘" />
-
-        <ImageView
-            android:id="@+id/previewImage"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="centerCrop"
-            android:contentDescription="미리보기 이미지"
-            android:visibility="invisible" />
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            android:paddingBottom="160dp"
+            android:src="@drawable/bg_ai_check_wave" />
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="30dp"
+            app:cardElevation="0dp"
+            android:layout_gravity="center"
+            app:cardPreventCornerOverlap="false"
+            app:cardUseCompatPadding="true">
+
+            <ImageView
+                android:id="@+id/placeholderIcon"
+                android:layout_width="363dp"
+                android:layout_height="400dp"
+                android:adjustViewBounds="true"
+                android:scaleType="fitCenter"
+                android:src="@drawable/img_shadow" />
+
+            <ImageView
+                android:id="@+id/previewImage"
+                android:layout_width="363dp"
+                android:layout_height="400dp"
+                android:scaleType="centerCrop"
+                android:contentDescription="미리보기 이미지"
+                android:visibility="invisible" />
+        </androidx.cardview.widget.CardView>
     </FrameLayout>
 
     <!-- 앨범 & 카메라 버튼 -->
     <LinearLayout
         android:id="@+id/cameraOptions"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:gravity="center"
-        android:layout_marginTop="16dp"
-        app:layout_constraintTop_toBottomOf="@id/previewArea"
+        android:orientation="horizontal"
+        android:layout_marginTop="-60dp"
+        app:layout_constraintBottom_toTopOf="@+id/btnCheck"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/previewArea">
 
         <LinearLayout
-            android:id="@+id/albumButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
+            android:layout_marginEnd="24dp"
             android:gravity="center"
-            android:layout_marginEnd="32dp">
+            android:orientation="vertical">
 
-            <ImageView
-                android:layout_width="56dp"
-                android:layout_height="56dp"
-                android:src="@drawable/ic_album"
-                android:contentDescription="앨범에서 이미지 선택" />
+            <ImageButton
+                android:id="@+id/albumButton"
+                android:layout_width="84dp"
+                android:layout_height="64dp"
+                android:background="@drawable/btn_round_background"
+                android:contentDescription="앨범 버튼"
+                android:padding="14dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_album" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="앨범"
-                android:textColor="#000000"
-                android:textSize="14sp"/>
+                android:textSize="20sp" />
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/cameraButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="center">
+            android:layout_marginStart="24dp"
+            android:gravity="center"
+            android:orientation="vertical">
 
-            <ImageView
-                android:layout_width="56dp"
-                android:layout_height="56dp"
-                android:src="@drawable/ic_camera"
-                android:contentDescription="카메라로 사진 촬영" />
+            <ImageButton
+                android:id="@+id/cameraButton"
+                android:layout_width="84dp"
+                android:layout_height="64dp"
+                android:background="@drawable/btn_round_background"
+                android:contentDescription="카메라 버튼"
+                android:padding="12dp"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_camera" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="카메라"
-                android:textColor="#000000"
-                android:textSize="14sp"/>
+                android:textSize="20sp" />
         </LinearLayout>
     </LinearLayout>
 
-    <!-- 검진하기 버튼 -->
+    <!-- 검진 버튼 -->
     <Button
         android:id="@+id/btnCheck"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:background="@drawable/btn_check_enabled"
+        android:layout_width="match_parent"
+        android:layout_height="74dp"
         android:text="검진하기"
-        android:textColor="@color/btn_check_text"
-        android:textStyle="bold"
-        android:textSize="16sp"
-        android:enabled="false"
-        app:layout_constraintTop_toBottomOf="@id/cameraOptions"
+        android:textSize="20dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginBottom="36dp"
+        android:textColor="@color/btn_next_text_selector"
+        android:background="@drawable/btn_next"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
-
+        android:enabled="true" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_skin_loading.xml
+++ b/app/src/main/res/layout/activity_skin_loading.xml
@@ -6,19 +6,6 @@
     android:layout_height="match_parent"
     android:background="#FFFFFF">
 
-    <!-- 🔙 뒤로 가기 버튼 -->
-
-    <ImageView
-        android:id="@+id/backButton"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="60dp"
-        android:contentDescription="뒤로 가기"
-        android:src="@drawable/ic_arrow_back"
-        app:layout_constraintHorizontal_bias="0.216"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
     <!-- 상단 벡터 배경 -->
     <View
         android:id="@+id/vectorBg"

--- a/app/src/main/res/layout/activity_skin_result.xml
+++ b/app/src/main/res/layout/activity_skin_result.xml
@@ -1,127 +1,157 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
     android:background="#FFFFFF"
+    android:padding="20dp"
     tools:context=".aiCheck.skin.SkinResultActivity">
 
-    <!-- 뒤로가기 버튼 -->
-
-    <!-- 타이틀 -->
-
-    <!-- 결과 스크롤 뷰 -->
-    <ImageView
-        android:id="@+id/backButton"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="60dp"
-        android:contentDescription="뒤로 가기"
-        android:src="@drawable/ic_arrow_back"
-        app:layout_constraintEnd_toStartOf="@+id/top_title"
+    <!-- 상단 내비게이션 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_top_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent">
 
+        <ImageButton
+            android:id="@+id/back_button"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_margin="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_arrow_back"
+            android:contentDescription="뒤로 가기"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <TextView
+            android:id="@+id/top_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="AI 스마트 간편 검진"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- 메인 타이틀 -->
     <TextView
-        android:id="@+id/top_title"
+        android:id="@+id/main_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="44dp"
-        android:text="AI 스마트 간편 검진"
-        android:textColor="#000000"
-        android:textSize="18sp"
+        android:layout_marginTop="12dp"
+        android:gravity="center"
+        android:text="피부 스마트 검진 결과"
+        android:textSize="28sp"
         android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:includeFontPadding="false"
+        android:paddingVertical="10dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_top_nav"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent" />
 
+    <!-- 날짜 텍스트 -->
+    <TextView
+        android:id="@+id/result_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="2025.04.21(월) 21:00"
+        android:textSize="12sp"
+        android:textColor="#A3A3A3"
+        android:includeFontPadding="false"
+        app:layout_constraintTop_toBottomOf="@id/main_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 종합 건강도 카드 -->
+    <include
+        android:id="@+id/summary_block_wrapper"
+        layout="@layout/item_skin_result_summary_card"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:layout_marginHorizontal="10dp"
+        app:layout_constraintTop_toBottomOf="@id/result_date"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 범례 -->
+    <LinearLayout
+        android:id="@+id/layout_score_hint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:layout_marginHorizontal="10dp"
+        android:background="@drawable/rounded_white_background"
+        android:backgroundTint="#E6E6E6"
+        android:paddingVertical="10dp"
+        android:layout_marginTop="16dp"
+        android:elevation="4dp"
+        app:layout_constraintTop_toBottomOf="@id/summary_block_wrapper"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:layout_marginHorizontal="12dp"
+            android:text="● 안심"
+            android:textColor="#377DFF"
+            android:textSize="16sp"
+            android:includeFontPadding="false"/>
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:layout_marginHorizontal="12dp"
+            android:text="● 주의"
+            android:textColor="#4CAF50"
+            android:textSize="16sp"
+            android:includeFontPadding="false"/>
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:layout_marginHorizontal="12dp"
+            android:text="● 의심"
+            android:textColor="#D32F2F"
+            android:textSize="16sp"
+            android:includeFontPadding="false"/>
+    </LinearLayout>
+
+    <!-- 결과 카드 목록 -->
     <androidx.core.widget.NestedScrollView
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:fillViewport="true"
         android:layout_marginTop="16dp"
-        app:layout_constraintTop_toBottomOf="@id/top_title"
+        app:layout_constraintTop_toBottomOf="@id/layout_score_hint"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
         <LinearLayout
-            android:id="@+id/result_container"
+            android:id="@+id/skin_result_card_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <!-- 메인 제목 -->
-            <TextView
-                android:id="@+id/main_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="피부 스마트 검진 결과"
-                android:textSize="20sp"
-                android:textStyle="bold"
-                android:textColor="#000000"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="8dp" />
-
-            <!-- 날짜 -->
-            <TextView
-                android:id="@+id/result_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="2025.04.21(월) 21:00"
-                android:textColor="#888888"
-                android:textSize="14sp"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="4dp" />
-
-            <!-- 종합 건강도 카드 -->
-            <include layout="@layout/item_skin_result_summary_card" />
-
-            <!-- 범례 -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center"
-                android:background="@drawable/rounded_white_background"
-                android:padding="8dp"
-                android:layout_marginTop="12dp"
-                android:layout_marginBottom="16dp"
-                android:elevation="4dp">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="● 안심"
-                    android:textColor="#377DFF"
-                    android:textSize="12sp"
-                    android:layout_marginEnd="12dp" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="● 주의"
-                    android:textColor="#4CAF50"
-                    android:textSize="12sp"
-                    android:layout_marginEnd="12dp" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="● 의심"
-                    android:textColor="#D32F2F"
-                    android:textSize="12sp" />
-            </LinearLayout>
-
-            <!-- 개별 결과 카드 반복적으로 삽입됨 -->
-            <LinearLayout
-                android:id="@+id/skin_result_card_container"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_marginBottom="32dp" />
-        </LinearLayout>
+            android:orientation="vertical"
+            android:layout_marginBottom="32dp" />
     </androidx.core.widget.NestedScrollView>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_skin_history_card.xml
+++ b/app/src/main/res/layout/item_skin_history_card.xml
@@ -1,37 +1,39 @@
-<!-- res/layout/item_skin_history_card.xml -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/rounded_white_bg"
+    android:backgroundTint="#F0F0F0"
     android:orientation="horizontal"
     android:gravity="center_vertical"
     android:padding="16dp"
     android:layout_marginBottom="10dp"
+    android:layout_marginHorizontal="26dp"
     android:elevation="2dp">
 
     <LinearLayout
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingHorizontal="20dp">
 
         <TextView
             android:id="@+id/historyDate"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="2dp"
+            android:includeFontPadding="false"
             android:text="2025.04.21(월) 21:00"
-            android:textColor="#909090"
-            android:textSize="12sp"
-            android:layout_marginBottom="2dp"/>
+            android:textColor="#000000"
+            android:textSize="16sp" />
 
         <TextView
             android:id="@+id/historyTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="피부 종합 건강도 "
-            android:textColor="#222222"
-            android:textStyle="bold"
-            android:textSize="16sp"/>
+            android:includeFontPadding="false"
+            android:text="피부 종합 건강도"
+            android:textColor="#8E8E8E"
+            android:textSize="14sp"/>
     </LinearLayout>
 
     <TextView
@@ -42,6 +44,5 @@
         android:textColor="#377DFF"
         android:textSize="24sp"
         android:textStyle="bold"
-        android:paddingStart="8dp"
-        android:paddingEnd="4dp"/>
+        android:layout_marginLeft="60dp"/>
 </LinearLayout>

--- a/app/src/main/res/layout/item_skin_result_card.xml
+++ b/app/src/main/res/layout/item_skin_result_card.xml
@@ -1,25 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="100dp"
+    android:layout_height="wrap_content"
     android:orientation="horizontal"
     android:background="@drawable/rounded_white_background"
+    android:backgroundTint="#FFFFFF"
     android:padding="16dp"
-    android:elevation="4dp"
-    android:layout_marginBottom="20dp"
+    android:layout_marginHorizontal="10dp"
+    android:layout_marginTop="14dp"
+    android:layout_marginBottom="10dp"
+    android:elevation="6dp"
     android:gravity="center_vertical">
 
-    <!-- 왼쪽 썸네일 또는 아이콘 -->
+    <!-- 왼쪽 이미지 -->
     <ImageView
         android:id="@+id/condition_image"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:background="@drawable/rounded_gray_background"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
         android:scaleType="centerCrop"
-        android:layout_marginEnd="16dp"
-        android:contentDescription="피부 이미지" />
+        android:src="@drawable/ic_skin_placeholder"
+        android:background="@drawable/image_round_rect"
+        android:contentDescription="피부 이미지"
+        android:layout_marginEnd="16dp" />
 
-    <!-- 중앙 텍스트 (제목) -->
+    <!-- 중앙 텍스트 + 점수 -->
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -31,35 +34,29 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="증상 이름"
-            android:textSize="16sp"
+            android:textSize="20sp"
             android:textStyle="bold"
-            android:textColor="#000000" />
-    </LinearLayout>
-
-    <!-- 오른쪽 점수 -->
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:gravity="center_vertical|end">
+            android:textColor="#000000"
+            android:layout_marginBottom="4dp"
+            android:includeFontPadding="false"/>
 
         <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:text="의심도"
-            android:textSize="12sp"
-            android:textColor="#999999"
-            android:layout_gravity="end" />
-
-        <TextView
-            android:id="@+id/condition_score"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="37%"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            android:textColor="#377DFF"
-            android:layout_gravity="end" />
+            android:textColor="#999999"
+            android:textSize="14sp"
+            android:includeFontPadding="false"/>
     </LinearLayout>
 
+    <!-- 점수 -->
+    <TextView
+        android:id="@+id/condition_score"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="37%"
+        android:textColor="#377DFF"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:includeFontPadding="false"/>
 </LinearLayout>

--- a/app/src/main/res/layout/item_skin_result_summary_card.xml
+++ b/app/src/main/res/layout/item_skin_result_summary_card.xml
@@ -1,61 +1,62 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="110dp"
+    android:layout_height="wrap_content"
     android:orientation="horizontal"
     android:background="@drawable/rounded_white_background"
-    android:padding="16dp"
-    android:elevation="4dp"
-    android:layout_marginTop="12dp"
+    android:backgroundTint="#FFFFFF"
+    android:padding="20dp"
+    android:elevation="6dp"
+    android:layout_marginTop="14dp"
+    android:layout_marginHorizontal="10dp"
     android:gravity="center_vertical">
 
-    <!-- 왼쪽 썸네일 영역 -->
+    <!-- 썸네일 이미지 -->
     <ImageView
         android:id="@+id/summary_image"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:background="@drawable/rounded_gray_background"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
         android:scaleType="centerCrop"
+        android:src="@drawable/ic_skin_placeholder"
+        android:background="@drawable/image_round_rect"
         android:layout_marginEnd="16dp"
         android:contentDescription="종합 건강도 이미지" />
 
-    <!-- 중앙 텍스트 영역 -->
-    <TextView
-        android:id="@+id/summary_title"
+    <!-- 텍스트 + 점수 -->
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:text="종합 피부 건강도"
-        android:textSize="16sp"
-        android:textStyle="bold"
-        android:textColor="#000000"
-        android:gravity="center_vertical" />
+        android:orientation="vertical">
 
-    <!-- 오른쪽 수직 영역 -->
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:gravity="center_vertical|end">
+        <TextView
+            android:id="@+id/summary_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="종합 피부 건강도"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:textColor="#000000"
+            android:layout_marginBottom="4dp"
+            android:includeFontPadding="false"/>
 
         <TextView
             android:id="@+id/summary_score_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="건강도"
-            android:textSize="12sp"
+            android:textSize="14sp"
             android:textColor="#888888"
-            android:layout_gravity="end" />
-
-        <!-- 여기를 summaryScore로 ID 수정 -->
-        <TextView
-            android:id="@+id/summaryScore"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="50%"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            android:textColor="#4CAF50"
-            android:layout_marginTop="4dp"
-            android:layout_gravity="end" />
+            android:includeFontPadding="false"/>
     </LinearLayout>
+
+    <!-- 점수 -->
+    <TextView
+        android:id="@+id/summaryScore"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="50%"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:textColor="#4CAF50"
+        android:includeFontPadding="false"/>
 </LinearLayout>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-files-path
-        name="my_images"
-        path="." />
+    <!-- 앱 캐시 디렉토리 -->
     <cache-path
         name="cache"
+        path="." />
+
+    <!-- 외부 파일 디렉토리 -->
+    <external-files-path
+        name="external_files"
+        path="." />
+
+    <!-- 내부 파일 디렉토리 (선택사항) -->
+    <files-path
+        name="internal_files"
         path="." />
 </paths>


### PR DESCRIPTION
feat: AI 검사 히스토리 탭 통합 및 최신순 정렬 구현

- EyeLoadingActivity: 안구 분석 결과 Firebase 저장 시 createdAt 필드에 포맷된 문자열 날짜 저장 추가
- AICheckActivity:
  - 안구/피부 히스토리 탭 구분 제거, 하나의 화면에서 모든 히스토리 통합 표시
  - createdAt 기준으로 정렬되도록 각 카드 상단 삽입 방식으로 변경
  - 히스토리 카드에 '종합 안구 건강도', '종합 피부 건강도' 제목으로 타입 구분
  - 탭 선택 로직, 불필요한 분기 제거 및 clearHistoryList 단순화
- Firebase 구조에 맞춰 EyeAnalysis와 SkinAnalysis 경로에서 데이터 동기화 구현
